### PR TITLE
DS-4353 - Bugfix incorrect time comparison to token expiration.

### DIFF
--- a/src/Auth/JwtToken.php
+++ b/src/Auth/JwtToken.php
@@ -43,7 +43,7 @@ class JwtToken
 
     public function isExpired(): bool
     {
-        if ($this->expires > (time() - 600)) {
+        if ($this->expires > (time() + 600)) {
             return false;
         }
 

--- a/tests/Auth/JwtTokenTest.php
+++ b/tests/Auth/JwtTokenTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Auth;
+
+use AllDigitalRewards\RewardStack\Auth\JwtToken;
+use PHPUnit\Framework\TestCase;
+
+class JwtTokenTest extends TestCase
+{
+
+    public function testIsExpired()
+    {
+        $jwtToken = new JwtToken('token', time());
+
+        // It expires 10 minutes before the current time.
+        self::assertTrue($jwtToken->isExpired());
+    }
+
+    public function testIsNotExpired()
+    {
+        $jwtToken = new JwtToken('token', time() + 700);
+
+        // It expires 10 minutes before the current time.
+        self::assertFalse($jwtToken->isExpired());
+    }
+}


### PR DESCRIPTION
## Description
DS-4353 - Bugfix incorrect time comparison to token expiration.

## Jira Issue Link
DS-4353

## Has the README / documentation been extended if necessary?
No

## Does this update require changes to public API documentation? 
No

## Tests
### Are there created tests which fail without the change (if possible)?
Yes

### Are all tests passing?
Yes

<img width="678" alt="Screen Shot 2022-08-19 at 18 52 54" src="https://user-images.githubusercontent.com/6137941/185724766-454ef2df-e27e-48bc-b027-f378e293f3eb.png">


### Have the changes been verified to comply with the security policy requirements?
Yes
