### PR TITLE
DS-13293: CreateAdjustmentRequest shareable as a genuine bool (shareable batch upload)

### DIFF
--- a/src/Adjustment/CreateAdjustmentRequest.php
+++ b/src/Adjustment/CreateAdjustmentRequest.php
@@ -48,7 +48,7 @@ class CreateAdjustmentRequest extends AbstractApiRequest
     private $completedAt;
 
     /**
-     * @var int|null
+     * @var bool
      */
     private $shareable;
 
@@ -64,18 +64,18 @@ class CreateAdjustmentRequest extends AbstractApiRequest
      * @param string|null $description
      * @param string|null $activity
      * @param string|null $completedAt
-     * @param int|null $shareable Set to 1 for shareable points, 0 for earned points
+     * @param bool $shareable True routes the amount to the participant's shareable balance
      */
     public function __construct(
         string $programId,
         string $uniqueId,
         string $type,
         string $pointAmount,
-        string $referenceId = null,
-        string $description = null,
-        string $activity = null,
-        string $completedAt = null,
-        int $shareable = null
+        ?string $referenceId = null,
+        ?string $description = null,
+        ?string $activity = null,
+        ?string $completedAt = null,
+        bool $shareable = false
     ) {
         $this->programId = $programId;
         $this->uniqueId = $uniqueId;
@@ -100,19 +100,14 @@ class CreateAdjustmentRequest extends AbstractApiRequest
 
     public function jsonSerialize(): array
     {
-        $data = [
+        return [
             "type" => $this->type,
             "amount" => $this->pointAmount,
             "reference" => $this->referenceId,
             'description' => $this->description,
             'activity' => $this->activity,
             'completed_at' => $this->completedAt,
+            'shareable' => $this->shareable,
         ];
-
-        if ($this->shareable !== null) {
-            $data['shareable'] = $this->shareable;
-        }
-
-        return $data;
     }
 }

--- a/tests/Request/CreateAdjustmentRequestTest.php
+++ b/tests/Request/CreateAdjustmentRequestTest.php
@@ -66,6 +66,7 @@ class CreateAdjustmentRequestTest extends TestCase
             "description" => $this->description,
             "activity" => $this->activity,
             "completed_at" => $this->completedAt,
+            "shareable" => false,
         ];
 
         $this->assertEquals(
@@ -74,7 +75,7 @@ class CreateAdjustmentRequestTest extends TestCase
         );
     }
 
-    public function testJsonSerializeWithShareable()
+    public function testJsonSerializeWithShareableTrue()
     {
         $shareableRequest = new Adjustment\CreateAdjustmentRequest(
             $this->program,
@@ -85,8 +86,10 @@ class CreateAdjustmentRequestTest extends TestCase
             $this->description,
             $this->activity,
             $this->completedAt,
-            1 // shareable
+            true // shareable
         );
+
+        $serialized = $shareableRequest->jsonSerialize();
 
         $expectedArray = [
             "type" => $this->type,
@@ -95,19 +98,36 @@ class CreateAdjustmentRequestTest extends TestCase
             "description" => $this->description,
             "activity" => $this->activity,
             "completed_at" => $this->completedAt,
-            "shareable" => 1,
+            "shareable" => true,
         ];
 
-        $this->assertEquals(
-            $expectedArray,
-            $shareableRequest->jsonSerialize()
-        );
+        $this->assertEquals($expectedArray, $serialized);
+        // Must be a genuine JSON boolean, not 1/"true" — see ADR-0002 coercion trap.
+        $this->assertArrayHasKey('shareable', $serialized);
+        $this->assertSame(true, $serialized['shareable']);
     }
 
-    public function testJsonSerializeWithoutShareable()
+    public function testJsonSerializeDefaultsShareableToFalse()
     {
-        // When shareable is null, it should not be included in the output
+        // shareable is always present and defaults to a genuine boolean false.
         $serialized = $this->createAdjustmentRequest->jsonSerialize();
-        $this->assertArrayNotHasKey('shareable', $serialized);
+        $this->assertArrayHasKey('shareable', $serialized);
+        $this->assertSame(false, $serialized['shareable']);
+    }
+
+    public function testJsonSerializeKeepsExistingKeysUnchanged()
+    {
+        // The six pre-existing keys must be untouched by the shareable addition.
+        $serialized = $this->createAdjustmentRequest->jsonSerialize();
+        $this->assertSame(
+            ['type', 'amount', 'reference', 'description', 'activity', 'completed_at', 'shareable'],
+            array_keys($serialized)
+        );
+        $this->assertEquals($this->type, $serialized['type']);
+        $this->assertEquals($this->amount, $serialized['amount']);
+        $this->assertEquals($this->referenceId, $serialized['reference']);
+        $this->assertEquals($this->description, $serialized['description']);
+        $this->assertEquals($this->activity, $serialized['activity']);
+        $this->assertEquals($this->completedAt, $serialized['completed_at']);
     }
 }


### PR DESCRIPTION
## DS-13293 — Issue Shareable Points via File Upload (SDK portion)

The batch **adjustment** upload gains an orthogonal `Shareable` (YES/NO) column so an admin can bulk-issue points into a participant's `shared_credit` balance. For the pipeline to tell `/adjustment` that a row is shareable, `CreateAdjustmentRequest` must carry the flag and serialize it as a **genuine JSON boolean** — rewardstack `Balance::createAdjustment` does `(bool)($data['shareable'] ?? false)`, and per **ADR-0002** ints/strings hit PHP coercion traps (`(bool)"false" === true`). The upload pipeline normalizes `YES`/`NO` → a real PHP `bool` *before* the SDK, and the request must preserve that type.

### What changed
- Constructor 9th param `int $shareable = null` → **`bool $shareable = false`**.
- `jsonSerialize()` now **always** emits `shareable` as a genuine JSON bool (previously conditional on non-null, and serialized an `int`).
- Made the pre-existing nullable string params explicitly nullable (`?string`) to clear the file's PHP 8.4 implicit-nullable deprecations (no signature-compat change — `?string` == `string|null`).

### ⚠ DS-12238 collision (why the semantics changed vs 5.7.0)
5.7.0 shipped a `shareable` on this class from **DS-12238 (P2P sharing)** as `int $shareable = null`, conditionally serialized. That semantic is wrong for DS-13293 (and is itself the coercion trap ADR-0002 warns about). Investigation confirmed changing it is **safe**:
- **P2P is unaffected.** The P2P path is driven by `SharePointsRequest` (`/share` endpoint); it does **not** consume `CreateAdjustmentRequest::shareable`. The int flag added in DS-12238 was never read by the P2P implementation — only the SDK's own unit test passed an int.
- **Other SDK consumers unaffected.** `service-awards-service` and `milestones` construct this request with 8 args; they now serialize `shareable: false`, which rewardstack coerces to `false` → identical behavior.
- The new consumer, `api-batch-facilitator` (`CreateIssuance::generateAdjustmentIssuanceRequest`), passes `$issuance->getIssuanceShareable(): bool` as the 9th positional arg and relies on `jsonSerialize()['shareable']` being a genuine bool.

### Version decision (for the maintainer — not tagged here)
5.7.0 already released the int-nullable `shareable`, so this flips a public constructor param type and makes serialization unconditional — breaking-ish. **Recommend `5.8.0`** (the int variant had no real consumer, so practical blast radius is nil), though a strict-semver **`6.0.0`** is defensible. **No tag/release is created by this PR** — left to the maintainer. The `api-batch-facilitator` composer bump is a separate, coordinated step and is intentionally not touched here.

### Tests (TDD: RED → GREEN)
Rewrote `CreateAdjustmentRequestTest` serialization cases to the bool contract (watched them fail against the int impl first):
- `shareable: true` → `jsonSerialize()['shareable'] === true` (strict, not `1`/`"true"`).
- default (param omitted) → `shareable === false`, always present.
- the six existing keys (`type`/`amount`/`reference`/`description`/`activity`/`completed_at`) unchanged.

Full SDK suite: **80 tests / 290 assertions green**. `phpcs` clean on both changed files. (Pre-existing, unrelated deprecations/phpcs errors in other files were left out of scope.)

Refs: DS-13293
