### PR TITLE
Update Adjustment History in MP UI for P2P

### DIFF
--- a/src/Common/Entity/Adjustment.php
+++ b/src/Common/Entity/Adjustment.php
@@ -14,6 +14,9 @@ class Adjustment extends AbstractEntity
     protected $reference;
     protected $description;
     protected $shareable;
+    protected $share_direction;
+    protected $counterparty_name;
+    protected $share_message;
     protected $id;
     protected $created_at;
     protected $updated_at;
@@ -215,5 +218,53 @@ class Adjustment extends AbstractEntity
     public function isShareable(): bool
     {
         return $this->shareable == 1;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getShareDirection()
+    {
+        return $this->share_direction;
+    }
+
+    /**
+     * @param string|null $share_direction
+     */
+    public function setShareDirection($share_direction)
+    {
+        $this->share_direction = $share_direction;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCounterpartyName()
+    {
+        return $this->counterparty_name;
+    }
+
+    /**
+     * @param string|null $counterparty_name
+     */
+    public function setCounterpartyName($counterparty_name)
+    {
+        $this->counterparty_name = $counterparty_name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getShareMessage()
+    {
+        return $this->share_message;
+    }
+
+    /**
+     * @param string|null $share_message
+     */
+    public function setShareMessage($share_message)
+    {
+        $this->share_message = $share_message;
     }
 }

--- a/tests/Response/AdjustmentShareContextTest.php
+++ b/tests/Response/AdjustmentShareContextTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AllDigitalRewards\Tests;
+
+use AllDigitalRewards\RewardStack\Common\Entity\Adjustment;
+use PHPUnit\Framework\TestCase;
+
+class AdjustmentShareContextTest extends TestCase
+{
+    public function testHydratesShareContextFields()
+    {
+        $adjustment = new Adjustment([
+            'amount' => 300,
+            'type' => 'credit',
+            'reference' => 'share-492e1c34',
+            'description' => 'Thanks for covering my shift - coffee on me!',
+            'shareable' => 1,
+            'id' => 23,
+            'share_direction' => 'received',
+            'counterparty_name' => 'Give Points',
+            'share_message' => 'Thanks for covering my shift - coffee on me!',
+        ]);
+
+        $this->assertSame('received', $adjustment->getShareDirection());
+        $this->assertSame('Give Points', $adjustment->getCounterpartyName());
+        $this->assertSame('Thanks for covering my shift - coffee on me!', $adjustment->getShareMessage());
+    }
+
+    public function testShareContextFieldsDefaultToNull()
+    {
+        $adjustment = new Adjustment([
+            'amount' => 500,
+            'type' => 'credit',
+            'id' => 300,
+        ]);
+
+        $this->assertNull($adjustment->getShareDirection());
+        $this->assertNull($adjustment->getCounterpartyName());
+        $this->assertNull($adjustment->getShareMessage());
+    }
+
+    public function testSentDirectionWithoutMessage()
+    {
+        $adjustment = new Adjustment([
+            'reference' => 'share-cd1a99',
+            'shareable' => 1,
+            'share_direction' => 'sent',
+            'counterparty_name' => 'def@email.com',
+            'share_message' => null,
+        ]);
+
+        $this->assertSame('sent', $adjustment->getShareDirection());
+        $this->assertSame('def@email.com', $adjustment->getCounterpartyName());
+        $this->assertNull($adjustment->getShareMessage());
+    }
+
+    public function testShareContextSettersAndGetters()
+    {
+        $adjustment = new Adjustment();
+
+        $adjustment->setShareDirection('sent');
+        $adjustment->setCounterpartyName('Get Points');
+        $adjustment->setShareMessage('Here you go');
+
+        $this->assertSame('sent', $adjustment->getShareDirection());
+        $this->assertSame('Get Points', $adjustment->getCounterpartyName());
+        $this->assertSame('Here you go', $adjustment->getShareMessage());
+    }
+}


### PR DESCRIPTION
## Description

Adds three P2P share-context fields to the SDK client `Adjustment` DTO (`src/Common/Entity/Adjustment.php`):

- `share_direction` (`"sent"` | `"received"`)
- `counterparty_name` (the other participant's name, or email fallback)
- `share_message` (the sender's message, or `null` for system auto-text)

These are populated at read-time by the rewardstack participant API (`OutputNormalizer::getAdjustmentList`, separate PR) and hydrated automatically via `AbstractEntity`'s setter-based mapping. This unblocks marketplace-client rendering "Points Sent/Received from {name}" with the message inline (separate PR).

This is the SDK leg of DS-13313, which spans three repos (SDK → rewardstack API → marketplace-client).

## Assumptions

None.

## Jira Issue Link

https://alldigitalrewards.atlassian.net/browse/DS-13313

## Has the README / documentation been extended if necessary?

No — additive DTO fields, no public-API doc surface change.

## Does this update require changes to public API documentation?

No.

## Tests

### Are there created tests which fail without the change (if possible)?

Yes — `tests/Response/AdjustmentShareContextTest.php` (4 tests) fails against master (undefined getters) and passes with the change. Full suite: 84/84 green.

### Have the changes been verified to comply with the security policy requirements?

Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)